### PR TITLE
Fix uppercase extension issue

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -70,7 +70,7 @@ class ETPlugin_Attachments extends ETPlugin {
 		 */
 		function formatAttachment($attachment, $expanded = false)
 		{
-			$extension = pathinfo($attachment["filename"], PATHINFO_EXTENSION);
+			$extension = strtolower(pathinfo($attachment["filename"], PATHINFO_EXTENSION));
 			$url = URL("attachment/".$attachment["attachmentId"]."_".$attachment["filename"]);
 			$filename = sanitizeHTML($attachment["filename"]);
 			$displayFilename = ET::formatter()->init($filename)->highlight(ET::$session->get("highlight"))->get();


### PR DESCRIPTION
Convert $extension to lowercase with strtolower so that extensions in uppercase will display thumbnails properly.